### PR TITLE
Fix invisible Quick Open dropdown

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1751,7 +1751,7 @@ textarea.exclusions-editor {
     box-shadow: 0 5px 10px @bc-shadow;
     opacity: 0;
     
-    .animation (autocomplete, 90ms, cubic-bezier(.01, .91, 0, .99), 0, 1);
+    .animation (autocomplete, 90ms, cubic-bezier(.01, .91, 0, .99));
     -webkit-animation-fill-mode: forwards;
     animation-fill-mode: forwards;
     -webkit-transform-origin: 0 0;

--- a/src/styles/brackets_mixins.less
+++ b/src/styles/brackets_mixins.less
@@ -141,7 +141,7 @@
     user-select: @type;
 }
 
-.animation (@name, @duration: 300ms, @ease: ease, @delay: 0, @iteration-count: 1) {
+.animation (@name, @duration: 300ms, @ease: ease, @delay: 0ms, @iteration-count: 1) {
     -webkit-animation: @name @duration @ease @delay @iteration-count;
     animation: @name @duration @ease @delay @iteration-count;
 }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -282,7 +282,7 @@ a:focus {
 
 // Dropdown Menu Animation
 .dropdown-menu {
-    .animation(dropdown, 90ms, cubic-bezier(0, .97, .2, .99), 0, 1);
+    .animation(dropdown, 90ms, cubic-bezier(0, .97, .2, .99));
     -webkit-transform-origin: 0 0;
     border: none;
     border-radius: @bc-border-radius;
@@ -755,7 +755,7 @@ a:focus {
     position: relative;
     top: 0;
     margin: auto;
-    .animation(modal, 240ms, cubic-bezier(0, 1.05, .35, 1), 0, 1);
+    .animation(modal, 240ms, cubic-bezier(0, 1.05, .35, 1));
 
     .dark & {
         background-color: @dark-bc-panel-bg;
@@ -857,7 +857,7 @@ a:focus {
 }
 
 .modal-backdrop {
-    .animation (backdrop, 200ms, linear, 0, 1);
+    .animation (backdrop, 200ms, linear);
     opacity: @bc-modal-backdrop-opacity;
 
     .dark & {


### PR DESCRIPTION
Chrome seems to have changed its mind on non-`ms` animation durations.
With that fix, the Quick Open dropdown is finally visible. I've also patched all other occurences (not too many).

One general question:
As this is a patch that could also go into core Brackets, should we rather open a PR over there to get it in?
