### PR TITLE
set the temp folder so extensions install/update properly

### DIFF
--- a/app/shell-config.js
+++ b/app/shell-config.js
@@ -8,7 +8,6 @@ var app = require("app");
 var fs = require("fs-extra");
 var path = require("path");
 var utils = require("./utils");
-var process = require("process");
 var os = require("os");
 
 var CONFIG_PATH = path.resolve(utils.convertWindowsPathToUnixPath(app.getPath("userData")), "shell-config.json");

--- a/app/shell-config.js
+++ b/app/shell-config.js
@@ -8,9 +8,15 @@ var app = require("app");
 var fs = require("fs-extra");
 var path = require("path");
 var utils = require("./utils");
+var process = require("process");
+var os = require("os");
 
 var CONFIG_PATH = path.resolve(utils.convertWindowsPathToUnixPath(app.getPath("userData")), "shell-config.json");
 var config;
+
+if (!process.env["TMPDIR"] && !process.env["TMP"] && !process.env["TEMP"]) {
+    process.env["TMPDIR"] = process.env["TMP"] = process.env["TEMP"] = os.tmpdir();
+}
 
 try {
     config = fs.readJsonSync(CONFIG_PATH);


### PR DESCRIPTION
Installing extensions on Linux was resulting in an error where the temp path to the downloaded file was being appended to the pwd.. like `/home/mackenza/projects/brackets-electron/tmp/...`

I pulled this code from https://github.com/adobe/brackets-shell/blob/master/appshell/node-core/Launcher.js

I am not sure if this code belongs in `shell-config.js` but it seems like a decent place. Feel free to move it if you feel otherwise.
