### PR TITLE
Save editor state on quit

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+    FILE_CLOSE_WINDOW:      "file.close_window"
+};

--- a/app/preload.js
+++ b/app/preload.js
@@ -1,6 +1,8 @@
 (function () {
     "use strict";
 
+    var Constants = require("./constants");
+
     // expose electron renderer process modules, uncomment those required
     window.electron = {
         node: {
@@ -19,6 +21,10 @@
     // notify shell about resizes
     window.onresize = function () {
         window.electron.ipc.send("resize");
+    };
+
+    window.onbeforeunload = function () {
+        window.brackets.shellAPI.executeCommand(Constants.FILE_CLOSE_WINDOW, true);
     };
 
     // move injected node variables, do not move "process" as that'd break node.require


### PR DESCRIPTION
We need this bit of code to trigger [_handleWindowGoingAway](https://github.com/adobe/brackets/blob/5daf5bea63b0ef602d3213427c1edb6a987150ba/src/document/DocumentCommandHandlers.js#L1354-L1382) (the most important line in there is actually `ProjectManager.trigger("beforeAppClose");`)
