### PR TITLE
Update dependencies

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -9,7 +9,6 @@ var appInfo = require("../package.json");
 var path = require("path");
 var app = require("app"); // Electron module to control application life
 var BrowserWindow = require("browser-window"); // Electron to create native browser window
-var ipc = require("ipc"); // Electron ipc module
 var SocketServer = require("./socket-server"); // Implementation of Brackets' shell server
 var utils = require("./utils");
 var shellConfig = require("./shell-config");
@@ -124,7 +123,10 @@ function openBracketsWindow(queryObj) {
     win.on("unmaximize", function () {
         saveWindowPosition(win);
     });
-    ipc.on("resize", function () {
+    win.on("resize", function () {
+        saveWindowPosition(win);
+    });
+    win.on("move", function () {
         saveWindowPosition(win);
     });
 

--- a/app/preload.js
+++ b/app/preload.js
@@ -13,11 +13,6 @@
         // shell: require("shell")
     };
 
-    // notify shell about resizes
-    window.onresize = function () {
-        window.electron.ipc.send("resize");
-    };
-
     // move injected node variables, do not move "process" as that'd break node.require
     window.node = {
         process: window.process

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
         "SHA": ""
     },
     "dependencies": {
-        "bluebird": "2.9.25",
-        "fs-extra": "0.18.3",
+        "bluebird": "2.9.27",
+        "fs-extra": "0.18.4",
         "isbinaryfile": "2.0.4",
-        "lodash": "3.9.1",
+        "lodash": "3.9.3",
         "lodash-deep": "1.6.0",
         "portscanner": "1.0.0",
         "strip-bom": "1.0.0",
@@ -31,8 +31,8 @@
     },
     "devDependencies": {
         "electron-packager": "https://github.com/zaggino/electron-packager.git",
-        "electron-prebuilt": "0.26.1",
-        "electron-rebuild": "0.1.4",
+        "electron-prebuilt": "0.27.2",
+        "electron-rebuild": "0.2.1",
         "grunt": "0.4.5",
         "grunt-cleanempty": "1.0.3",
         "grunt-cli": "0.1.13",

--- a/src/config.json
+++ b/src/config.json
@@ -37,10 +37,10 @@
         "SHA": ""
     },
     "dependencies": {
-        "bluebird": "2.9.25",
-        "fs-extra": "0.18.3",
+        "bluebird": "2.9.27",
+        "fs-extra": "0.18.4",
         "isbinaryfile": "2.0.4",
-        "lodash": "3.9.1",
+        "lodash": "3.9.3",
         "lodash-deep": "1.6.0",
         "portscanner": "1.0.0",
         "strip-bom": "1.0.0",
@@ -54,8 +54,8 @@
     },
     "devDependencies": {
         "electron-packager": "https://github.com/zaggino/electron-packager.git",
-        "electron-prebuilt": "0.26.0",
-        "electron-rebuild": "0.1.4",
+        "electron-prebuilt": "0.27.2",
+        "electron-rebuild": "0.2.1",
         "grunt": "0.4.5",
         "grunt-cleanempty": "1.0.3",
         "grunt-cli": "0.1.13",


### PR DESCRIPTION
Most notably, Atom is now 0.27.2

Furthermore, we no longer need to send `resize` events through `ipc` - they are now emitted by the window itself.
