### PR TITLE
Updated some dependencies.

### DIFF
--- a/app/appshell/app-menu.js
+++ b/app/appshell/app-menu.js
@@ -5,7 +5,9 @@
 var _ = require("lodash");
 var main = require("../index");
 var assert = require("assert");
-var Menu = require("menu");
+
+var electron = require("electron");
+var Menu = electron.Menu;
 
 var menuTemplate = [];
 

--- a/app/appshell/app.js
+++ b/app/appshell/app.js
@@ -6,7 +6,8 @@ var assert = require("assert");
 var shell = require("shell");
 var utils = require("../utils");
 
-var remote = require("remote");
+var electron = require("electron");
+var remote = electron.remote;
 var electronApp = remote.require("app");
 var shellState = remote.require("./shell-state");
 

--- a/app/appshell/index.js
+++ b/app/appshell/index.js
@@ -3,7 +3,9 @@
 "use strict";
 
 var _ = require("lodash");
-var remote = require("remote");
+var electron = require("electron");
+
+var remote = electron.remote;
 var app = _.extend({}, require("./app"), remote.require("./appshell/app-menu"));
 var fs = _.extend({}, require("fs-extra"), require("./fs-additions"));
 

--- a/app/brackets-window.js
+++ b/app/brackets-window.js
@@ -6,8 +6,11 @@
 // see https://github.com/atom/electron/blob/master/docs/api/window-open.md
 
 var assert = require("assert");
-var BrowserWindow = require("browser-window");
 var URL = require("url");
+
+var electron = require("electron");
+var BrowserWindow = electron.BrowserWindow;
+
 var windows = {};
 
 function resolveUrl(url) {

--- a/app/index.js
+++ b/app/index.js
@@ -7,16 +7,18 @@
 var _ = require("lodash");
 var appInfo = require("../package.json");
 var path = require("path");
-var app = require("app"); // Electron module to control application life
-var BrowserWindow = require("browser-window"); // Electron to create native browser window
 var SocketServer = require("./socket-server"); // Implementation of Brackets' shell server
 var utils = require("./utils");
 var shellConfig = require("./shell-config");
 var shellState = require("./shell-state");
 
+var electron = require("electron");
+var app = electron.app; // Electron module to control application life
+var BrowserWindow = electron.BrowserWindow; // Electron to create native browser window
+
 // Report crashes to electron server
 // TODO: doesn't work
-// require("crash-reporter").start();
+// electron.crashReporter.start();
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.

--- a/app/preload.js
+++ b/app/preload.js
@@ -1,17 +1,11 @@
 (function () {
     "use strict";
 
-    // expose electron renderer process modules, uncomment those required
-    window.electron = {
-        ipc: require("ipc"),
-        remote: require("remote")
-        // webFrame: require("web-frame"),
-        // clipboard: require("clipboard"),
-        // crashReporter: require("crash-reporter"),
-        // nativeImage: require("native-image"),
-        // screen: require("screen"),
-        // shell: require("shell")
-    };
+    // expose electron renderer process modules
+    window.electron = require("electron");
+
+    // TODO: found the reason why ipcRenderer/ipcMain aren't enough...
+    window.electron.ipc = require("ipc");
 
     // move injected node variables, do not move "process" as that'd break node.require
     window.node = {
@@ -26,11 +20,5 @@
     window.process.versions["node-webkit"] = true;
 
     // inject appshell implementation into the browser window
-    try { // TODO: remove try-catch when issue fixed - https://github.com/atom/electron/issues/1566
-        window.appshell = window.brackets = window.node.require("../app/appshell");
-    } catch (e) {
-        console.log(e.stack);
-        throw e;
-    }
-
+    window.appshell = window.brackets = window.node.require("../app/appshell");
 }());

--- a/app/shell-config.js
+++ b/app/shell-config.js
@@ -4,11 +4,13 @@
 
 var _ = require("lodash");
 _.mixin(require("lodash-deep"));
-var app = require("app");
 var fs = require("fs-extra");
 var path = require("path");
 var utils = require("./utils");
 var os = require("os");
+
+var electron = require("electron");
+var app = electron.app;
 
 var CONFIG_PATH = path.resolve(utils.convertWindowsPathToUnixPath(app.getPath("userData")), "shell-config.json");
 var config;

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
         "ws": "0.8.0"
     },
     "optionalDependencies": {
-        "fsevents": "1.0.0",
-        "pathwatcher": "6.2.5"
+        "fsevents": "1.0.6",
+        "pathwatcher": "6.3.1"
     },
     "devDependencies": {
-        "electron-packager": "https://github.com/zaggino/electron-packager.git",
-        "electron-prebuilt": "0.33.1",
-        "electron-rebuild": "1.0.0",
+        "electron-packager": "5.2.0",
+        "electron-prebuilt": "0.36.3",
+        "electron-rebuild": "1.1.1",
         "grunt": "0.4.5",
         "grunt-cleanempty": "1.0.3",
         "grunt-cli": "0.1.13",
@@ -63,9 +63,9 @@
         "postinstall": "grunt install",
         "test": "grunt cla-check-pull test",
         "start": "electron .",
-        "bundle-mac": "./bundle.sh darwin x64 0.26.0",
-        "bundle-win": "bundle.sh win32 x64 0.26.0",
-        "bundle-linux": "bundle.sh linux x64 0.26.0"
+        "bundle-mac": "./bundle.sh darwin x64 0.36.3",
+        "bundle-win": "bundle.sh win32 x64 0.36.3",
+        "bundle-linux": "bundle.sh linux x64 0.36.3"
     },
     "licenses": [
         {

--- a/src/config.json
+++ b/src/config.json
@@ -49,13 +49,13 @@
         "ws": "0.8.0"
     },
     "optionalDependencies": {
-        "fsevents": "1.0.0",
-        "pathwatcher": "6.2.5"
+        "fsevents": "1.0.6",
+        "pathwatcher": "6.3.1"
     },
     "devDependencies": {
-        "electron-packager": "https://github.com/zaggino/electron-packager.git",
-        "electron-prebuilt": "0.33.1",
-        "electron-rebuild": "1.0.0",
+        "electron-packager": "5.2.0",
+        "electron-prebuilt": "0.36.3",
+        "electron-rebuild": "1.1.1",
         "grunt": "0.4.5",
         "grunt-cleanempty": "1.0.3",
         "grunt-cli": "0.1.13",
@@ -86,9 +86,9 @@
         "postinstall": "grunt install",
         "test": "grunt cla-check-pull test",
         "start": "electron .",
-        "bundle-mac": "./bundle.sh darwin x64 0.26.0",
-        "bundle-win": "bundle.sh win32 x64 0.26.0",
-        "bundle-linux": "bundle.sh linux x64 0.26.0"
+        "bundle-mac": "./bundle.sh darwin x64 0.36.3",
+        "bundle-win": "bundle.sh win32 x64 0.36.3",
+        "bundle-linux": "bundle.sh linux x64 0.36.3"
     },
     "licenses": [
         {


### PR DESCRIPTION
Electron has changed a bit its structure so mostly changes are because of it.
I needed to still use the deprecate require of `ipc` because using the new `ipcMain` or `ipcRenderer` both caused some problem:

``` javascript
window.electron.ipc = require("ipc");
```
