### PR TITLE
Support native module in extensions

### DIFF
--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -37,7 +37,8 @@ define(function (require, exports, module) {
         ExtensionLoader      = require("utils/ExtensionLoader"),
         NodeConnection       = require("utils/NodeConnection"),
         PreferencesManager   = require("preferences/PreferencesManager"),
-        PathUtils            = require("thirdparty/path-utils/path-utils");
+        PathUtils            = require("thirdparty/path-utils/path-utils"),
+        electronVersion      = brackets.metadata.devDependencies.electron;
 
     PreferencesManager.definePreference("proxy", "string", undefined, {
         description: Strings.DESCRIPTION_PROXY
@@ -115,6 +116,7 @@ define(function (require, exports, module) {
             // so npm can use it in the domain
             options = options || {};
             options.proxy = PreferencesManager.get("proxy");
+            options.electronVersion = electronVersion;
             
             extensionManager.validate(path, options)
                 .done(function (result) {
@@ -168,7 +170,8 @@ define(function (require, exports, module) {
                 systemExtensionDirectory: systemDirectory,
                 apiVersion: brackets.metadata.apiVersion,
                 nameHint: nameHint,
-                proxy: PreferencesManager.get("proxy")
+                proxy: PreferencesManager.get("proxy"),
+                electronVersion: electronVersion
             })
                 .done(function (result) {
                     result.keepFile = false;

--- a/src/extensibility/node/npm-installer.js
+++ b/src/extensibility/node/npm-installer.js
@@ -37,22 +37,13 @@ var Errors = {
  * Private function to run "npm install --production" command in the extension directory.
  *
  * @param {string} installDirectory Directory to remove
+ * @param {array} npmOptions can contain additional options like `--production` or `--proxy http://127.0.0.1:8888`
  * @param {function} callback NodeJS style callback to call after finish
  */
 function _performNpmInstall(installDirectory, npmOptions, callback) {
     var npmPath = path.resolve(path.dirname(require.resolve("npm")), "..", "bin", "npm-cli.js");
-    var args = [npmPath, "install"];
-    
-    // npmOptions can contain additional args like { "production": true, "proxy": "http://127.0.0.1:8888" }
-    Object.keys(npmOptions).forEach(function (key) {
-        var value = npmOptions[key];
-        if (value === true) {
-            args.push("--" + key);
-        } else if (typeof value === "string" && value.length > 0) {
-            args.push("--" + key, value);
-        }
-    });
-    
+    var args = [npmPath, "install"].concat(npmOptions);
+
     console.log("running npm " + args.slice(1).join(" ") + " in " + installDirectory);
 
     var child = spawn(process.execPath, args, { cwd: installDirectory });

--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -295,10 +295,20 @@ function extractAndValidateFiles(zipPath, extractDir, options, callback) {
                     errors.push([Errors.MISSING_MAIN, zipPath, mainJS]);
                 }
 
-                performNpmInstallIfRequired({
-                    production: true,
-                    proxy: options.proxy
-                }, {
+                var npmOptions = ['--production'];
+
+                if (options.proxy) {
+                    npmOptions.push('--proxy ' + options.proxy);
+                }
+
+                if (process.platform.startsWith('win')) {
+                    // On Windows force a 32 bit build until nodejs 64 bit is supported.
+                    npmOptions.push('--arch=ia32');
+                    npmOptions.push('--npm_config_arch=ia32');
+                    npmOptions.push('--npm_config_target_arch=ia32');
+                }
+
+                performNpmInstallIfRequired(npmOptions, {
                     errors: errors,
                     metadata: metadata,
                     commonPrefix: commonPrefix,

--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -311,7 +311,10 @@ function extractAndValidateFiles(zipPath, extractDir, options, callback) {
     unzipper.extract({
         path: extractDir,
         filter: function (file) {
-            return file.type !== "SymbolicLink";
+            console.log(JSON.stringify(file));
+            return file.type !== "SymbolicLink" &&
+              // Exclude toplevel .npmrc file
+              !(file.filename === ".npmrc" && file.path === ".npmrc");
         }
     });
 }

--- a/src/extensibility/node/package-validator.js
+++ b/src/extensibility/node/package-validator.js
@@ -301,11 +301,14 @@ function extractAndValidateFiles(zipPath, extractDir, options, callback) {
                     npmOptions.push('--proxy ' + options.proxy);
                 }
 
-                if (process.platform.startsWith('win')) {
-                    // On Windows force a 32 bit build until nodejs 64 bit is supported.
-                    npmOptions.push('--arch=ia32');
-                    npmOptions.push('--npm_config_arch=ia32');
-                    npmOptions.push('--npm_config_target_arch=ia32');
+                npmOptions.push("--disturl=https://atom.io/download/electron");
+                npmOptions.push("--runtime=electron");
+                npmOptions.push("--target=" + options.electronVersion);
+
+                if (process.platform === "darwin") {
+                    npmOptions.push("--arch=x64");
+                } else {
+                    npmOptions.push("--arch=" + process.arch);
                 }
 
                 performNpmInstallIfRequired(npmOptions, {
@@ -321,7 +324,6 @@ function extractAndValidateFiles(zipPath, extractDir, options, callback) {
     unzipper.extract({
         path: extractDir,
         filter: function (file) {
-            console.log(JSON.stringify(file));
             return file.type !== "SymbolicLink" &&
               // Exclude toplevel .npmrc file
               !(file.filename === ".npmrc" && file.path === ".npmrc");


### PR DESCRIPTION
Add npm config variables to install native deps.
This should fix https://github.com/zaggino/brackets-electron/issues/89, so now it should be possible to install [brackets-terminal-x](https://github.com/ficristo/brackets-terminal-x) from the extension manager.

See https://github.com/electron/electron/blob/v1.6.6/docs/tutorial/using-native-node-modules.md#using-native-node-modules
I based this PR on https://github.com/adobe/brackets/pull/13384 by `git cherry-pick` its commit
https://github.com/adobe/brackets/commit/449299bfc8f6788212dbec9b2c4ada124d8bcb73