### PR TITLE
Reenable unit tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,9 @@ const watch = require('gulp-watch');
 const BASE_DIRS = ['app', 'src', 'samples'];
 const DIST_DIRS = ['dist', 'dist/www', 'dist/samples'];
 
+const BASE_TESTS_DIRS = ['test'];
+const DIST_TESTS_DIRS = ['dist/test'];
+
 function copyJs(filePath, srcDir, distDir) {
     const relative = path.relative(path.join(__dirname, srcDir), filePath);
     const from = path.join(srcDir, relative);
@@ -27,11 +30,22 @@ gulp.task('copy-src-dist', (_cb) => {
     });
 });
 
-gulp.task('watch', ['copy-src-dist'], () => {
-    BASE_DIRS.forEach((srcDir, idx) => {
+gulp.task('copy-test-dist', (_cb) => {
+    const cb = _.after(BASE_TESTS_DIRS.length, _cb);
+    BASE_TESTS_DIRS.forEach((srcDir, idx) => {
+        gulp.src(`${srcDir}/**/!(*.ts|*.tsx)`)
+            .pipe(gulp.dest(DIST_TESTS_DIRS[idx]))
+            .on('end', cb);
+    });
+});
+
+gulp.task('watch', ['copy-src-dist', 'copy-test-dist'], () => {
+    const BASE_WATCH_DIRS = BASE_DIRS.concat(BASE_TESTS_DIRS);
+    const DIST_WATCH_DIRS = DIST_DIRS.concat(DIST_TESTS_DIRS);
+    BASE_WATCH_DIRS.forEach((srcDir, idx) => {
         watch(`${srcDir}/**/!(*.ts|*.tsx)`, file => {
-            copyJs(file.path, srcDir, DIST_DIRS[idx]);
-            console.log(`copied modified ${file.path} from ${srcDir} to ${DIST_DIRS[idx]}`);
+            copyJs(file.path, srcDir, DIST_WATCH_DIRS[idx]);
+            console.log(`copied modified ${file.path} from ${srcDir} to ${DIST_WATCH_DIRS[idx]}`);
         });
     });
 });

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -136,7 +136,7 @@ define(function LiveDevelopment(require, exports, module) {
 
     // special case for test/SpecRunner.html since we can't tell how requirejs
     // baseUrl is configured dynamically
-    launcherUrl = launcherUrl.replace("/test/SpecRunner.html", "/src/index.html");
+    launcherUrl = launcherUrl.replace("/test/SpecRunner.html", "/www/index.html");
 
     launcherUrl = launcherUrl.substr(0, launcherUrl.lastIndexOf("/")) + "/LiveDevelopment/launch.html";
     launcherUrl = window.location.origin + launcherUrl;

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -58,9 +58,9 @@ define(function (require, exports, module) {
      */
     var contexts    = {};
 
-    // The native directory path ends with either "test" or "src". We need "src" to
+    // The native directory path ends with either "test" or "www". We need "www" to
     // load the text and i18n modules.
-    srcPath = srcPath.replace(/\/test$/, "/src"); // convert from "test" to "src"
+    srcPath = srcPath.replace(/\/test$/, "/www"); // convert from "test" to "www"
 
 
     // Retrieve the global paths

--- a/test/BootstrapReporterView.js
+++ b/test/BootstrapReporterView.js
@@ -339,7 +339,7 @@ define(function (require, exports, module) {
         // Convert from symlinked path to real path - otherwise Brackets will think they are two separate files.
         // Note: we assume the current project open in our parent Brackets window is the Brackets source
         var bracketsRoot = FileUtils.getNativeBracketsDirectoryPath();
-        if (bracketsRoot.substr(bracketsRoot.length - 4) === "/src") {
+        if (bracketsRoot.substr(bracketsRoot.length - 4) === "/www") {
             var symlinkPrefix = bracketsRoot.substring(0, bracketsRoot.length - 3);  // include trailing "/"
             if (path.indexOf(symlinkPrefix) === 0) {
                 var realPrefix = ProjectManager.getProjectRoot().fullPath;

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -35,12 +35,12 @@
 
   <!-- Pre-load third party scripts that cannot be async loaded. -->
   <!-- Keep in sync with Gruntfile.js jasmine vendor dependencies -->
-  <script src="../src/thirdparty/jquery-2.1.3.min.js"></script>
-  <script src="../src/thirdparty/less.min.js"></script>
+  <script src="../www/thirdparty/jquery-2.1.3.min.js"></script>
+  <script src="../www/thirdparty/less.min.js"></script>
   <script src="thirdparty/bootstrap2/js/bootstrap.min.js"></script>
 
   <!-- All other scripts are loaded through require. -->
-  <script src="../src/thirdparty/requirejs/require.js" data-main="SpecRunner"></script>
+  <script src="../node_modules/requirejs/require.js" data-main="SpecRunner"></script>
 
 </head>
 

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -23,9 +23,9 @@
 
 /*global beforeEach, afterEach, beforeFirst, afterLast, jasmine */
 
-// Set the baseUrl to brackets/src
+// Set the baseUrl to dist/www
 require.config({
-    baseUrl: "../src",
+    baseUrl: "../www",
     paths: {
         "test"                          : "../test",
         "perf"                          : "../test/perf",
@@ -134,7 +134,7 @@ define(function (require, exports, module) {
         }
 
         // This returns path to test folder, so convert to src
-        bracketsPath = bracketsPath.replace(/\/test$/, "/src");
+        bracketsPath = bracketsPath.replace(/\/test$/, "/www");
 
         return Async.doInParallel(paths, function (dir) {
             var extensionPath = dir;


### PR DESCRIPTION
Integration tests cannot run because it still fails to create a test window.

Tests now are run from the dist/test folder